### PR TITLE
Fix Security Issue

### DIFF
--- a/complete/src/main/java/hello/FileUploadController.java
+++ b/complete/src/main/java/hello/FileUploadController.java
@@ -29,7 +29,7 @@ public class FileUploadController {
 
 	private static final Logger log = LoggerFactory.getLogger(FileUploadController.class);
 
-	public static String ROOT = "upload-dir";
+	public static final String ROOT = "upload-dir";
 
 	private final ResourceLoader resourceLoader;
 


### PR DESCRIPTION
The short is that if somehow there were a malicious class on the classpath having the field be public and static would allow any class to change it. It would be better if the tutorial didn't use this. I don't actually think the constant needs to be public.

from findbugs

>
Returning a reference to a mutable object value stored in one of the object's fields exposes the internal representation of the object.  If instances are accessed by untrusted code, and unchecked changes to the mutable object would compromise security or other important properties, you will need to do something different. Returning a new copy of the object is better approach in many situations.