### PR TITLE
use a more typed way of defining a URI

### DIFF
--- a/complete/src/main/java/hello/FileUploadController.java
+++ b/complete/src/main/java/hello/FileUploadController.java
@@ -55,7 +55,7 @@ public class FileUploadController {
 	public ResponseEntity<?> getFile(@PathVariable String filename) {
 
 		try {
-			return ResponseEntity.ok(resourceLoader.getResource("file:" + Paths.get(ROOT, filename).toString()));
+			return ResponseEntity.ok(resourceLoader.getResource(Paths.get(ROOT, filename).toUri().toString()));
 		} catch (Exception e) {
 			return ResponseEntity.notFound().build();
 		}


### PR DESCRIPTION
has the benefit of being obvious that the method is taking a URI, even if as a string.
