### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,9 @@
 :spring_version: current
 :spring_boot_version: 1.5.10.RELEASE
-:Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:ResponseBody: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
-:SpringBootApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/SpringBootApplication.html
+:Controller: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:ResponseBody: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
+:SpringBootApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/SpringBootApplication.html
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -67,7 +67,7 @@ In this case:
 * `GET /files/{filename}` loads the resource if it exists, and sends it to the browser to download using a `"Content-Disposition"` response header
 * `POST /` is geared to handle a multi-part message `file` and give it to the `StorageService` for saving
 
-NOTE: In a production scenario, you more likely would store the files in a temporary location, a database, or perhaps a NoSQL store like http://docs.mongodb.org/manual/core/gridfs[Mongo's GridFS]. It's is best to NOT load up the file system of your application with content.
+NOTE: In a production scenario, you more likely would store the files in a temporary location, a database, or perhaps a NoSQL store like https://docs.mongodb.org/manual/core/gridfs[Mongo's GridFS]. It's is best to NOT load up the file system of your application with content.
 
 You will need to provide a `StorageService` for the controller to interact with a storage layer (e.g. a file system). The interface is like this:
 
@@ -91,7 +91,7 @@ include::complete/src/main/resources/templates/uploadForm.html[]
 
 This template has three parts:
 
-* An optional message at the top where Spring MVC writes a http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#mvc-flash-attributes[flash-scoped messages].
+* An optional message at the top where Spring MVC writes a https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#mvc-flash-attributes[flash-scoped messages].
 * A form allowing the user to upload files
 * A list of files supplied from the backend
 

--- a/complete/src/main/resources/templates/uploadForm.html
+++ b/complete/src/main/resources/templates/uploadForm.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <body>
 
 	<div th:if="${message}">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://www.thymeleaf.org with 1 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://docs.mongodb.org/manual/core/gridfs with 1 occurrences migrated to:  
  https://docs.mongodb.org/manual/core/gridfs ([https](https://docs.mongodb.org/manual/core/gridfs) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost/files/first.txt with 1 occurrences
* http://localhost/files/second.txt with 1 occurrences
* http://localhost:8080/ with 1 occurrences