### PR TITLE
Fix save file security issue

### DIFF
--- a/complete/src/main/java/com/example/uploadingfiles/storage/FileSystemStorageService.java
+++ b/complete/src/main/java/com/example/uploadingfiles/storage/FileSystemStorageService.java
@@ -29,24 +29,25 @@ public class FileSystemStorageService implements StorageService {
 
 	@Override
 	public void store(MultipartFile file) {
-		String filename = StringUtils.cleanPath(file.getOriginalFilename());
 		try {
 			if (file.isEmpty()) {
-				throw new StorageException("Failed to store empty file " + filename);
+				throw new StorageException("Failed to store empty file.");
 			}
-			if (filename.contains("..")) {
+			Path destinationFile = this.rootLocation.resolve(
+					Paths.get(file.getOriginalFilename()))
+					.normalize().toAbsolutePath();
+			if (!destinationFile.getParent().equals(this.rootLocation.toAbsolutePath())) {
 				// This is a security check
 				throw new StorageException(
-						"Cannot store file with relative path outside current directory "
-								+ filename);
+						"Cannot store file outside current directory.");
 			}
 			try (InputStream inputStream = file.getInputStream()) {
-				Files.copy(inputStream, this.rootLocation.resolve(filename),
+				Files.copy(inputStream, destinationFile,
 					StandardCopyOption.REPLACE_EXISTING);
 			}
 		}
 		catch (IOException e) {
-			throw new StorageException("Failed to store file " + filename, e);
+			throw new StorageException("Failed to store file.", e);
 		}
 	}
 

--- a/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
+++ b/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
@@ -55,10 +55,26 @@ public class FileSystemStorageServiceTests {
 	}
 
 	@Test
-	public void saveNotPermitted() {
+	public void saveRelativePathNotPermitted() {
 		assertThrows(StorageException.class, () -> {
 			service.store(new MockMultipartFile("foo", "../foo.txt",
-			MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
+					MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
+		});
+	}
+
+	@Test
+	public void saveWinAbsolutePathNotPermitted() {
+		assertThrows(StorageException.class, () -> {
+			service.store(new MockMultipartFile("foo", "C:\\foo.txt",
+					MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
+		});
+	}
+
+	@Test
+	public void saveUnixAbsolutePathNotPermitted() {
+		assertThrows(StorageException.class, () -> {
+			service.store(new MockMultipartFile("foo", "/etc/passwd",
+					MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
 		});
 	}
 

--- a/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
+++ b/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
@@ -63,15 +63,7 @@ public class FileSystemStorageServiceTests {
 	}
 
 	@Test
-	public void saveWinAbsolutePathNotPermitted() {
-		assertThrows(StorageException.class, () -> {
-			service.store(new MockMultipartFile("foo", "C:\\foo.txt",
-					MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
-		});
-	}
-
-	@Test
-	public void saveUnixAbsolutePathNotPermitted() {
+	public void saveAbsolutePathNotPermitted() {
 		assertThrows(StorageException.class, () -> {
 			service.store(new MockMultipartFile("foo", "/etc/passwd",
 					MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));

--- a/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
+++ b/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
@@ -71,6 +71,14 @@ public class FileSystemStorageServiceTests {
 	}
 
 	@Test
+	public void saveAbsolutePathInNameNotPermitted() {
+		assertThrows(StorageException.class, () -> {
+			service.store(new MockMultipartFile("\\etc\\passwd", "\\etc\\passwd",
+					MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
+		});
+	}
+
+	@Test
 	public void savePermitted() {
 		service.store(new MockMultipartFile("foo", "bar/../foo.txt",
 				MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));

--- a/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
+++ b/complete/src/test/java/com/example/uploadingfiles/storage/FileSystemStorageServiceTests.java
@@ -15,16 +15,21 @@
  */
 package com.example.uploadingfiles.storage;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Random;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Dave Syer
@@ -71,11 +76,14 @@ public class FileSystemStorageServiceTests {
 	}
 
 	@Test
-	public void saveAbsolutePathInNameNotPermitted() {
-		assertThrows(StorageException.class, () -> {
-			service.store(new MockMultipartFile("\\etc\\passwd", "\\etc\\passwd",
-					MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
-		});
+	@EnabledOnOs({OS.LINUX})
+	public void saveAbsolutePathInFilenamePermitted() {
+		//Unix file systems (e.g. ext4) allows backslash '\' in file names.
+		String fileName="\\etc\\passwd";
+		service.store(new MockMultipartFile(fileName, fileName,
+				MediaType.TEXT_PLAIN_VALUE, "Hello, World".getBytes()));
+		assertTrue(Files.exists(
+				Paths.get(properties.getLocation()).resolve(Paths.get(fileName))));
 	}
 
 	@Test


### PR DESCRIPTION
I would like to fix security issue in code for saving file. Currently code contains security check which validates relative paths. But there is no validation for absolute paths.

**How to use this bug?**
Send file setting up absolute path in request.

Assuming that application is started in the following way:

`docker run -it --rm -v $(pwd)/build/libs:/libs -p8080:8080  openjdk:8-slim /usr/local/openjdk-8/bin/java -jar  /libs/uploading-files-0.0.1-SNAPSHOT.jar
`

I see two possibilities to override /libs/uploading-files-0.0.1-SNAPSHOT.jar file:

**First:** Create file with any name e.g. 'hack.jar' and send this file overriding filename with absolute path: '/libs/uploading-files-0.0.1-SNAPSHOT.jar'.

`curl 'http://localhost:8080/' -F "file=@hack.jar;filename=/libs/uploading-files-0.0.1-SNAPSHOT.jar;"
`

**Second:** Create file with name '\\libs\\uploading-files-0.0.1-SNAPSHOT.jar' and send it to the server.

`curl 'http://localhost:8080/' -F "file=@\\libs\\uploading-files-0.0.1-SNAPSHOT.jar;"
`

Here we use another bug. Code use StringUtils.cleanPath for filename normalization, which will change '\' to '/'. Note that Unix file systems (e.g. ext4) allows backslash '\\' in file names.