### PR TITLE
Fix wrong dependency syntax in build.gradle

### DIFF
--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -15,7 +15,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation('org.springframework.boot:spring-boot-starter-test')\
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
 test {


### PR DESCRIPTION
Hi, I found this first at https://spring.io/guides/gs/uploading-files/

![image](https://user-images.githubusercontent.com/24666330/121459048-7efaee00-c9e5-11eb-8337-3b11ddef17e1.png)

I remove `\` in dependencies

Is this a source spring.io refer to? I think document in spring.io should be fixed too
