### PR TITLE
Fix 404 test case

### DIFF
--- a/complete/src/main/java/com/example/uploadingfiles/FileUploadController.java
+++ b/complete/src/main/java/com/example/uploadingfiles/FileUploadController.java
@@ -48,6 +48,10 @@ public class FileUploadController {
 	public ResponseEntity<Resource> serveFile(@PathVariable String filename) {
 
 		Resource file = storageService.loadAsResource(filename);
+
+		if (file == null)
+			return ResponseEntity.notFound().build();
+
 		return ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION,
 				"attachment; filename=\"" + file.getFilename() + "\"").body(file);
 	}

--- a/complete/src/test/java/com/example/uploadingfiles/FileUploadTests.java
+++ b/complete/src/test/java/com/example/uploadingfiles/FileUploadTests.java
@@ -15,7 +15,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;


### PR DESCRIPTION
The following test case does not pass with `complete`, so I have fixed it.
https://github.com/spring-guides/gs-uploading-files/blob/3329842a55d60c6051acb0b09a6dc87007873907/complete/src/test/java/com/example/uploadingfiles/FileUploadTests.java#L62